### PR TITLE
Adding in MDL

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "express": "~4.13.1",
     "extract-text-webpack-plugin": "^1.0.1",
     "hbs": "~3.1.0",
+    "material-design-icons": "^2.2.3",
+    "material-design-lite": "^1.1.3",
     "morgan": "~1.6.1",
     "node-sass-middleware": "0.8.0",
     "nuclear-js": "^1.3.0",
@@ -31,6 +33,7 @@
   "devDependencies": {
     "autoprefixer-loader": "^3.2.0",
     "css-loader": "^0.23.1",
+    "file-loader": "^0.8.5",
     "node-sass": "^3.7.0",
     "sass-loader": "^3.2.0",
     "style-loader": "^0.13.1"

--- a/src/client/assets/css/_fonts.scss
+++ b/src/client/assets/css/_fonts.scss
@@ -1,0 +1,6 @@
+@font-face {
+  font-family: "Material Icons";
+  font-style: normal;
+  font-weight: 400;
+  src: url("~material-design-icons/iconfont/MaterialIcons-Regular.ttf");
+}

--- a/src/client/assets/css/_material-design-lite.scss
+++ b/src/client/assets/css/_material-design-lite.scss
@@ -1,0 +1,21 @@
+@charset "UTF-8";
+
+// Variables and mixins
+@import "~material-design-lite/src/variables";
+@import "~material-design-lite/src/mixins";
+
+// Resets and dependencies
+@import "~material-design-lite/src/resets/resets";
+@import "~material-design-lite/src/typography/typography";
+
+// Global Components
+@import "~material-design-lite/src/grid/grid";
+@import "~material-design-lite/src/button/button";
+@import "~material-design-lite/src/layout/layout";
+@import "~material-design-lite/src/menu/menu";
+@import "~material-design-lite/src/card/card";
+@import "~material-design-lite/src/shadow/shadow";
+@import "~material-design-lite/src/progress/progress";
+@import "~material-design-lite/src/tabs/tabs";
+@import "~material-design-lite/src/slider/slider";
+@import "~material-design-lite/src/switch/switch";

--- a/src/client/assets/css/main.scss
+++ b/src/client/assets/css/main.scss
@@ -1,0 +1,8 @@
+@charset "UTF-8";
+
+// Material Design Lite
+// http://www.getmdl.io/
+@import "material-design-lite";
+@import "~material-design-lite/src/variables";
+
+@import "fonts";

--- a/src/client/pages/_common.jsx
+++ b/src/client/pages/_common.jsx
@@ -1,0 +1,1 @@
+import 'material-design-lite/material.min.js';

--- a/src/client/pages/_common_assets.jsx
+++ b/src/client/pages/_common_assets.jsx
@@ -1,0 +1,1 @@
+import '../assets/css/main.scss';

--- a/src/client/pages/main.jsx
+++ b/src/client/pages/main.jsx
@@ -3,7 +3,11 @@
 import React from 'react';
 import ReactDom from 'react-dom';
 
+// Main App Component
 import MainApp from '../modules/main/components/MainApp';
+
+import './_common';
+import './_common_assets';
 
 ReactDom.render(
   <div>

--- a/src/server/views/layout.hbs
+++ b/src/server/views/layout.hbs
@@ -6,6 +6,7 @@
   </head>
   <body>
     {{{body}}}
+    <script type="text/javascript" src="/build/common.js"></script>
     <script type="text/javascript" src='/build/{{js}}'></script>
   </body>
 </html>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,6 @@
 var ExtractTextPlugin = require("extract-text-webpack-plugin");
+var CommonsChunkPlugin = require('webpack/lib/optimize/CommonsChunkPlugin');
+var path = require('path');
 
 var sassLoaders = [
   'css-loader',
@@ -15,6 +17,7 @@ module.exports = {
   output: {
     filename: '[name].js',
     path: './src/client/build',
+    publicPath: '/build',
   },
 
   module: {
@@ -28,10 +31,22 @@ module.exports = {
         test: /\.scss$/,
         loader: ExtractTextPlugin.extract('style-loader', sassLoaders.join('!')),
       },
+      {
+        test: /\.(ttf|eot|woff(2)?)(\?[a-z0-9]+)?$/,
+        loader: 'file-loader?name=/[name].[ext]',
+      },
     ]
   },
 
+  resolve: {
+    extensions: ['', '.js', '.jsx', '.json'],
+    alias: {
+      react: path.resolve('./node_modules/react'), // ReactDom is trying to import its own React file, in this way it will load only one React
+    },
+  },
+
   plugins: [
-    new ExtractTextPlugin("[name].css")
+    new ExtractTextPlugin("[name].css"),
+    new CommonsChunkPlugin('common.js'),
   ]
 };


### PR DESCRIPTION
### Description
Adding in MDL and MDL icons.

### Expectations
We should now be able to make use of the MDL styling 

### What I did
- Added in the MDL library and MDL Icons
- Common css such as MDL is now sent down in a common chunk
- Appending common chunk to main layout

### Notes
It may be overkill to shove the MDL library into its own common chunk... or even to have the common chunk for page app, but it will allow for growth later on if we decide to add extra pages.