### PR TITLE
Card list carousel

### DIFF
--- a/core/modules/main/actions.js
+++ b/core/modules/main/actions.js
@@ -5,15 +5,8 @@ function completeTask(index) {
   reactor.dispatch(actionTypes.COMPLETE_TASK, { index });
 }
 
-function updateActiveTopic(activeIndex, maxIndex) {
-  let indexLeft = activeIndex - 1;
-  let indexRight = activeIndex + 1;
-  let newActiveIndexObject = {
-    indexLeft: (indexLeft >= 0 ? indexLeft : undefined),
-    indexActive: activeIndex,
-    indexRight:  (indexRight < maxIndex ? indexRight : undefined),
-  };
-  reactor.dispatch(actionTypes.UPDATE_ACTIVE_TOPIC, { newActiveIndexObject });
+function updateActiveTopic(newActiveIndex) {
+  reactor.dispatch(actionTypes.UPDATE_ACTIVE_TOPIC, { newActiveIndex });
 }
 
 let actions = {

--- a/core/modules/main/getters.js
+++ b/core/modules/main/getters.js
@@ -1,31 +1,9 @@
 import { toImmutable } from 'nuclear-js';
 
-const activeTopics = [
-  ['mainStore', 'data', 'subtopics'],
+const activeTopic = [
   ['mainStore', 'data', 'activeTopic'],
-  (subtopics, activeTopicobject) => {
-    let topicArray = [];
-
-    // Add Left Topic
-    if (!!activeTopicobject.get('indexLeft') || activeTopicobject.get('indexLeft') === 0) {
-      let indexLeft = activeTopicobject.get('indexLeft');
-      let topicLeft = subtopics.get(indexLeft);
-      topicArray.push(topicLeft);
-    }
-
-    // Add Active topic
-    let indexActive = activeTopicobject.get('indexActive');
-    let topicActive = subtopics.get(indexActive);
-    topicArray.push(topicActive);
-
-    // Add Right topic
-    if (!!activeTopicobject.get('indexRight')) {
-      let indexRight = activeTopicobject.get('indexRight');
-      let topicRight = subtopics.get(indexRight);
-      topicArray.push(topicRight);
-    }
-
-    return topicArray;
+  (activeTopic) => {
+    return activeTopic;
   },
 ];
 
@@ -39,6 +17,13 @@ const subTopicIndexs = [
   },
 ];
 
+const subTopics = [
+  ['mainStore', 'data', 'subtopics'],
+  (subtopics) => {
+    return subtopics;
+  },
+];
+
 const topicTitle = [
   ['mainStore', 'data', 'topic'],
   (topic) => {
@@ -47,7 +32,8 @@ const topicTitle = [
 ];
 
 export default {
-  activeTopics,
+  activeTopic,
   subTopicIndexs,
+  subTopics,
   topicTitle,
 }

--- a/core/modules/main/stores/MainStore/index.js
+++ b/core/modules/main/stores/MainStore/index.js
@@ -28,10 +28,7 @@ function getInitialState() {
         { index: 8, title: 'Revision', completed: false },
         { index: 9, title: 'Topic Test', completed: false }
       ],
-      activeTopic: {
-        indexActive: 0,
-        indexRight: 1,
-      },
+      activeTopic: 0,
     },
   });
 }
@@ -40,8 +37,8 @@ function onCompleteTask(state, { index }) {
   return state.updateIn(['data', 'subtopics', index, 'completed'], () => true);
 }
 
-function onUpdateActiveTopic(state, { newActiveIndexObject }) {
-  return state.mergeIn(['data', 'activeTopic'], newActiveIndexObject);
+function onUpdateActiveTopic(state, { newActiveIndex }) {
+  return state.updateIn(['data', 'activeTopic'], () => newActiveIndex);
 }
 
 export default MainStore;

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "nuclear-js": "^1.3.0",
     "react": "^15.1.0",
     "react-dom": "^15.1.0",
+    "react-slick": "^0.12.2",
     "serve-favicon": "~2.3.0",
     "webpack": "^1.13.1"
   },

--- a/src/client/modules/main/components/Container/index.js
+++ b/src/client/modules/main/components/Container/index.js
@@ -1,23 +1,38 @@
 import React from 'react';
+import Slider from 'react-slick';
 
 import Header from '../Header';
 import Navigation from '../Navigation';
 import TopicCard from '../TopicCard';
 import Footer from '../Footer';
 
+
 import './style.scss';
 
 const Container = React.createClass({
-  _renderTopicCard(topic, index) {
+  _getSliderSettings() {
+    return {
+      dots: false,
+      speed: 500,
+      centerMode: true,
+      slidesToShow: 3,
+      slidesToScroll: 1,
+      slickGoTo: this.props.activeTopic,
+      infinite: false,
+      lazyLoad: true,
+    };
+  },
 
+  _renderTopicCard(topic, index) {
     return (
-      <div key={index} className='mdl-cell mdl-cell--4-col'>
+      <div key={index}>
         <TopicCard topic={topic} />
       </div>
     );
   },
 
   render() {
+    let settings = this._getSliderSettings();
     return (
       <div className="mdl-layout mdl-js-layout mdl-layout--fixed-header">
         <Header
@@ -25,11 +40,14 @@ const Container = React.createClass({
           subTopicIndexs={this.props.subTopicIndexs} />
         <Navigation title={this.props.title} />
         <main className="mdl-layout__content">
-          <div className='topic-card__container mdl-grid'>
-            {
-              this.props.activeTopics.map(
-              (topic, index) => this._renderTopicCard(topic, index)
-            )}
+          <div className='topic-card__container'>
+            <Slider {...settings}>
+              {
+                this.props.subTopics.map(
+                  (topic, index) => this._renderTopicCard(topic, index)
+                )
+              }
+            </Slider>
           </div>
           <div className='mdl-tabs__panel' id='top'></div>
           <Footer />

--- a/src/client/modules/main/components/Container/style.scss
+++ b/src/client/modules/main/components/Container/style.scss
@@ -1,3 +1,14 @@
 .topic-card__container {
-  max-width: 1000px;
+  padding-top: 25px;
+}
+
+.slick-track {
+  min-height: 535px;
+}
+
+.slick-center {
+  .topic-card {
+    transition: all .3s ease;
+    transform: scale(1.08);
+  }
 }

--- a/src/client/modules/main/components/Header/index.js
+++ b/src/client/modules/main/components/Header/index.js
@@ -6,8 +6,7 @@ import './style.scss';
 
 const Header = React.createClass({
   _updateActiveTopic(index) {
-    let maxTopicArratLength = this.props.subTopicIndexs.size;
-    actions.updateActiveTopic(index, maxTopicArratLength);
+    actions.updateActiveTopic(index);
   },
 
   _renderNavTab(index) {

--- a/src/client/modules/main/components/MainApp/index.js
+++ b/src/client/modules/main/components/MainApp/index.js
@@ -14,8 +14,9 @@ const MainApp = React.createClass({
   getDataBindings() {
     return {
       title: getters.topicTitle,
-      activeTopics: getters.activeTopics,
+      activeTopic: getters.activeTopic,
       subTopicIndexs: getters.subTopicIndexs,
+      subTopics: getters.subTopics,
     };
   },
 
@@ -23,8 +24,9 @@ const MainApp = React.createClass({
     return (
       <Container
         title={this.state.title}
-        activeTopics={this.state.activeTopics}
-        subTopicIndexs={this.state.subTopicIndexs} />
+        activeTopic={this.state.activeTopic}
+        subTopicIndexs={this.state.subTopicIndexs}
+        subTopics={this.state.subTopics} />
     );
   },
 });

--- a/src/client/modules/main/components/TopicCard/style.scss
+++ b/src/client/modules/main/components/TopicCard/style.scss
@@ -1,7 +1,8 @@
 .topic-card {
   min-height: 500px !important;
   background: linear-gradient(170deg, #8C88FF 61%, #fff 50%) !important;
-  width: initial !important
+  width: initial !important;
+  margin: 10px;
 }
 
 .topic-card__title-container {
@@ -40,4 +41,5 @@
 .complete-button__image {
   background-color: #50D2C2;
   border-radius: 30px;
+  margin: auto;;
 }

--- a/src/server/views/layout.hbs
+++ b/src/server/views/layout.hbs
@@ -3,6 +3,7 @@
   <head>
     <title>{{title}}</title>
     <link rel='stylesheet' href='/build/{{css}}' />
+    <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.3.15/slick.css" />
   </head>
   <body>
     {{{body}}}


### PR DESCRIPTION
### Description
Adding a library to deal with card list display and transition.

### Expectations
- We should have a proper layout for the topic cards.
- We should see animations when we transition between different cards.

### What I did
- Added dependency for [react-slick](https://www.npmjs.com/package/react-slick) and CDN for its css library
- Updated core such that active is now just a simple int, and passing down the entire list of subtopics instead of just current active
- Added in the slider component and updated existing container and topic-card component to fit

### Notes
I chose the react-slick library based on the fact that it was a react adaptation of the [slick carousel](http://kenwheeler.github.io/slick/). This port is fine, however the library isn't perfect. There are couple of issues such as  the side two cards not disappearing off screen rather it just squishes in (personally I like this a bit more BUT it doesn't match requirements) but the biggest annoyance is that I discovered too late there is a bug that occurs sometimes with transitions where cards may become invisible until next transition.

### Screenshots 
<img width="1140" alt="screen shot 2016-06-05 at 9 48 07 pm" src="https://cloud.githubusercontent.com/assets/1269227/15805223/3b936cd6-2b67-11e6-905f-71c59019ff48.png">
